### PR TITLE
Update jaccard_similarity.py

### DIFF
--- a/simphile/jaccard_similarity.py
+++ b/simphile/jaccard_similarity.py
@@ -37,7 +37,7 @@ def jaccard_similarity(string_a, string_b):
 
 
 def jaccard_list_similarity(list_a, list_b):
-    assert len(list_a) > 0 or len(list_b > 0), "at least one list needs to have elements"
+    assert (len(list_a) > 0 or len(list_b) > 0), "at least one list needs to have elements"
     intersected = intersect(list_a, list_b)
     combined = list_a + list_b
     # did not use the union function for efficiency in sets.  Union also calculates intersection,


### PR DESCRIPTION
Typo in `jaccard_list_similarity` leads to incorrect errors:
```
File /opt/conda/lib/python3.9/site-packages/simphile/jaccard_similarity.py:40, in jaccard_list_similarity(list_a, list_b)
     39 def jaccard_list_similarity(list_a, list_b):
---> 40     assert len(list_a) > 0 or len(list_b > 0), "at least one list needs to have elements"
     41     intersected = intersect(list_a, list_b)
     42     combined = list_a + list_b

TypeError: '>' not supported between instances of 'list' and 'int'
```